### PR TITLE
Pour plugin in old modal layout

### DIFF
--- a/addon/components/editor-plugins/besluit-type-card.hbs
+++ b/addon/components/editor-plugins/besluit-type-card.hbs
@@ -1,10 +1,20 @@
-<p class="u-spacer--tiny">
-  <span>Besluit type: </span>
-  <BesluitTypeSelect @besluitTypes={{this.besluitTypes}} @onchange={{this.updateBesluitType}} @selected={{this.besluitType}} />
-</p>
-
-<WuButtonGroup>
-  <WuButton @label="Voeg in" class="button button--narrow" @onClick={{this.insert}} />
-</WuButtonGroup>
+<div class="modal-dialog modal-dialog--small modal-dialog--sectioned">
+  <div class="modal-dialog__header">
+    <div class="grid">
+      <div class="col--10-12">
+        <strong>Voeg een besluittype in:</strong>
+      </div>
+    </div>
+  </div>
+  <div class="modal-dialog__content">
+    <BesluitTypeSelect @besluitTypes={{this.besluitTypes}} @onchange={{this.updateBesluitType}} @selected={{this.besluitType}} />
+  </div>
+  <div class="modal-dialog__footer">
+    <WuButtonGroup>
+      <WuButton @label="Voeg in" class="button button--narrow" @onClick={{this.insert}} />
+    </WuButtonGroup>
+  </div>
+  {{yield}}
+</div>
 
 {{yield}}


### PR DESCRIPTION
I used the old modal, and we'll replace all plugins when the new appuniversum is in place in the next growth spurt.

To test everything, edl these two plugins into [https://github.com/lblod/frontend-gelinkt-notuleren](https://github.com/lblod/frontend-gelinkt-notuleren)
- [https://github.com/lblod/ember-rdfa-editor-besluit-type-plugin](https://github.com/lblod/ember-rdfa-editor-besluit-type-plugin)
- [https://github.com/lblod/ember-vo-webuniversum](https://github.com/lblod/ember-vo-webuniversum)