### PR TITLE
Make the peerdep requirement less strict

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^1.0.2",
-    "@lblod/ember-rdfa-editor": "^0.50.0"
+    "@lblod/ember-rdfa-editor": ">= 0.50.0"
   },
   "devDependencies": {
     "@appuniversum/ember-appuniversum": "^1.0.2",


### PR DESCRIPTION
In general peerdeps should be as loose as possible.
