### PR TITLE
improve config a bit

### DIFF
--- a/addon/utils/fetchBesluitTypes.js
+++ b/addon/utils/fetchBesluitTypes.js
@@ -40,7 +40,7 @@ export default async function fetchBesluitTypes(classificationUri, ENV) {
   const typeFetcher = new SparqlEndpointFetcher({
     method: 'POST',
   });
-  const endpoint = ENV['besluit-type-plugin']['besluit-types-endpoint'];
+  const endpoint = ENV.besluitTypePlugin.endpoint;
   const bindingStream = await typeFetcher.fetchBindings(endpoint, query);
   const validBesluitTriples = [];
   bindingStream.on('data', (triple) => {

--- a/config/environment.js
+++ b/config/environment.js
@@ -2,8 +2,8 @@
 
 module.exports = function (/* environment, appConfig */) {
   return {
-    'besluit-type-plugin': {
-      'besluit-types-endpoint': '{{BESLUIT_TYPES_SPARQL_ENDPOINT}}',
+    besluitTypePlugin: {
+      endpoint: 'https://centrale-vindplaats.lblod.info/sparql',
     },
   };
 };


### PR DESCRIPTION
dasherized keys are annoying to work with in JSON/JS Objects, so I've replaced
them with camelCased variants. Also changed the default value to the prod
endpoint, which makes more sense. If we want to make use of the ENV replacement
this can be done in the frontend.

In theory this is a breaking change, but since the plugin isn't used yet I suggest we do a patch release